### PR TITLE
Fixed a Victory check bug

### DIFF
--- a/ao-killboard.js
+++ b/ao-killboard.js
@@ -68,7 +68,7 @@ function parseKills(events) {
 
 function postKill(kill, channel = config.botChannel) {
     var victory = false;
-    if (kill.Killer.AllianceName == config.allianceName) {
+    if (kill.Killer.AllianceName.toLowerCase() == config.allianceName.toLowerCase() || kill.Killer.GuildName.toLowerCase() == config.guildName.toLowerCase()) {
         victory = true;
     }
 


### PR DESCRIPTION
The victory check was only checking Alliance names, not Guild names, and for the case where the Alliance is not set and only Guild kills are being displayed Victories were always shown as deaths.